### PR TITLE
feat: add Profile and Settings pages matching site theme

### DIFF
--- a/frontend/Auto-Sentry/src/pages/Profile/Profile.css
+++ b/frontend/Auto-Sentry/src/pages/Profile/Profile.css
@@ -1,0 +1,380 @@
+/* ════════════════════════════════════════
+   PROFILE PAGE — matches site theme
+════════════════════════════════════════ */
+
+.pf-page {
+  min-height: 100vh;
+  background: #f8f9fa;
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+.pf-container {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 0 40px;
+}
+
+/* ── HEADER ── */
+.pf-header {
+  background: #0a2640;
+  padding: 48px 0 40px;
+  position: relative;
+  overflow: hidden;
+}
+
+.pf-header-bg {
+  position: absolute;
+  width: 500px;
+  height: 500px;
+  background: #1c3d5b;
+  border-radius: 50%;
+  top: -280px;
+  right: -120px;
+  pointer-events: none;
+  opacity: 0.7;
+}
+
+.pf-header-inner {
+  position: relative;
+  z-index: 1;
+}
+
+.pf-eyebrow {
+  display: block;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: #5de0a5;
+  margin-bottom: 10px;
+}
+
+.pf-title {
+  font-size: 40px;
+  font-weight: 900;
+  color: white;
+  letter-spacing: -0.8px;
+  line-height: 1.1;
+  margin: 0 0 8px;
+}
+
+.pf-subtitle {
+  font-size: 15px;
+  color: rgba(255,255,255,0.5);
+}
+
+/* ── BODY ── */
+.pf-body {
+  padding: 40px 0 80px;
+}
+
+.pf-body-inner {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 28px;
+  align-items: start;
+}
+
+/* ════════════════════════════════════════
+   SIDEBAR — AVATAR CARD
+════════════════════════════════════════ */
+.pf-avatar-card {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 20px;
+  padding: 32px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  position: sticky;
+  top: 108px;
+}
+
+.pf-avatar-img {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 3px solid #5de0a5;
+  margin-bottom: 16px;
+}
+
+.pf-avatar-fallback {
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #5de0a5, #15cdfc);
+  color: #0a2640;
+  font-size: 36px;
+  font-weight: 900;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 16px;
+  border: 3px solid rgba(93,224,165,0.3);
+}
+
+.pf-name {
+  font-size: 18px;
+  font-weight: 800;
+  color: #111827;
+  margin: 0 0 4px;
+}
+
+.pf-nickname {
+  font-size: 13px;
+  color: #9ca3af;
+  margin: 0 0 12px;
+}
+
+.pf-verified-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #16a34a;
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  padding: 4px 12px;
+  border-radius: 20px;
+  margin-bottom: 4px;
+}
+
+.pf-avatar-divider {
+  height: 1px;
+  background: #f3f4f6;
+  width: 100%;
+  margin: 20px 0;
+}
+
+.pf-avatar-meta {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.pf-meta-label {
+  font-size: 12px;
+  color: #9ca3af;
+  font-weight: 500;
+}
+
+.pf-meta-value {
+  font-size: 13px;
+  color: #374151;
+  font-weight: 600;
+}
+
+.pf-edit-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 20px;
+  width: 100%;
+  justify-content: center;
+  padding: 11px 20px;
+  background: #f8f9fa;
+  color: #0a2640;
+  border: 1.5px solid #e5e7eb;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 700;
+  font-family: 'Inter', sans-serif;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+
+.pf-edit-btn:hover {
+  background: #0a2640;
+  color: white;
+  border-color: #0a2640;
+}
+
+/* ════════════════════════════════════════
+   MAIN COLUMN
+════════════════════════════════════════ */
+.pf-main {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* Shared card header */
+.pf-card-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 18px 24px;
+  background: #0a2640;
+}
+
+.pf-card-header h2 {
+  font-size: 16px;
+  font-weight: 700;
+  color: white;
+  margin: 0;
+}
+
+.pf-card-icon { color: #5de0a5; font-size: 15px; }
+
+/* ── INFO CARD ── */
+.pf-info-card {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 20px;
+  overflow: hidden;
+}
+
+.pf-info-rows {
+  padding: 8px 0;
+}
+
+.pf-info-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 24px;
+  border-bottom: 1px solid #f9fafb;
+  transition: background 0.15s;
+}
+
+.pf-info-row:last-child { border-bottom: none; }
+.pf-info-row:hover { background: #fafafa; }
+
+.pf-info-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 9px;
+  background: rgba(10,38,64,0.06);
+  color: #0a2640;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.pf-info-content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.pf-info-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: #9ca3af;
+}
+
+.pf-info-value {
+  font-size: 14px;
+  font-weight: 600;
+  color: #111827;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── QUICK LINKS CARD ── */
+.pf-links-card {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 20px;
+  overflow: hidden;
+}
+
+.pf-links-grid {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pf-link-item {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  text-decoration: none;
+  transition: background 0.15s;
+}
+
+.pf-link-item:hover { background: #f0fdf4; }
+
+.pf-link-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: rgba(10,38,64,0.06);
+  color: #0a2640;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 15px;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
+}
+
+.pf-link-item:hover .pf-link-icon {
+  background: #5de0a5;
+  color: #0a2640;
+}
+
+.pf-link-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.pf-link-label {
+  font-size: 14px;
+  font-weight: 700;
+  color: #111827;
+}
+
+.pf-link-desc {
+  font-size: 12px;
+  color: #9ca3af;
+}
+
+.pf-link-arrow {
+  color: #d1d5db;
+  font-size: 16px;
+  flex-shrink: 0;
+  transition: color 0.15s, transform 0.2s;
+}
+
+.pf-link-item:hover .pf-link-arrow {
+  color: #0a2640;
+  transform: translateX(3px);
+}
+
+/* ════════════════════════════════════════
+   RESPONSIVE
+════════════════════════════════════════ */
+@media (max-width: 768px) {
+  .pf-container { padding: 0 20px; }
+  .pf-header { padding: 36px 0 28px; }
+  .pf-title { font-size: 30px; }
+  .pf-body { padding: 28px 0 60px; }
+  .pf-body-inner {
+    grid-template-columns: 1fr;
+  }
+  .pf-avatar-card { position: static; }
+}
+
+@media (max-width: 480px) {
+  .pf-title { font-size: 26px; }
+  .pf-avatar-img,
+  .pf-avatar-fallback { width: 80px; height: 80px; font-size: 28px; }
+}

--- a/frontend/Auto-Sentry/src/pages/Profile/Profile.jsx
+++ b/frontend/Auto-Sentry/src/pages/Profile/Profile.jsx
@@ -1,0 +1,145 @@
+import { useAuth0 } from '@auth0/auth0-react';
+import { NavLink } from 'react-router-dom';
+import './Profile.css';
+import {
+  FaUser, FaEnvelope, FaIdBadge, FaCar,
+  FaShieldAlt, FaCog, FaCheckCircle,
+} from 'react-icons/fa';
+import { HiArrowRight } from 'react-icons/hi';
+
+const Profile = () => {
+  const { user, isAuthenticated } = useAuth0();
+
+  if (!isAuthenticated || !user) return null;
+
+  // Auth0 user fields
+  const joinDate = user.updated_at
+    ? new Date(user.updated_at).toLocaleDateString('en-GB', { month: 'long', year: 'numeric' })
+    : null;
+
+  const provider = user.sub?.split('|')[0] ?? 'auth0';
+  const providerLabel = {
+    google: 'Google',
+    auth0:  'Email / Password',
+    github: 'GitHub',
+  }[provider] ?? provider;
+
+  const INFO_ROWS = [
+    { icon: <FaUser />,    label: 'Full Name',   value: user.name        },
+    { icon: <FaEnvelope />,label: 'Email',       value: user.email       },
+    { icon: <FaIdBadge />, label: 'Username',    value: `@${user.nickname}` },
+    { icon: <FaShieldAlt />,label: 'Sign-in Via', value: providerLabel   },
+    ...(joinDate ? [{ icon: <FaCheckCircle />, label: 'Member Since', value: joinDate }] : []),
+  ];
+
+  const QUICK_LINKS = [
+    { to: '/garage',        icon: <FaCar />,     label: 'My Garage',      desc: 'View and manage your vehicles'         },
+    { to: '/servicehistory',icon: <FaCheckCircle />,label: 'Service History', desc: 'Browse your maintenance records'  },
+    { to: '/settings',      icon: <FaCog />,     label: 'Settings',       desc: 'Manage account preferences'           },
+  ];
+
+  return (
+    <div className="pf-page">
+
+      {/* ── HEADER ── */}
+      <div className="pf-header">
+        <div className="pf-header-bg" aria-hidden="true" />
+        <div className="pf-container pf-header-inner">
+          <span className="pf-eyebrow">Account</span>
+          <h1 className="pf-title">My Profile</h1>
+          <p className="pf-subtitle">Your account details and quick access to key features.</p>
+        </div>
+      </div>
+
+      {/* ── BODY ── */}
+      <div className="pf-body">
+        <div className="pf-container pf-body-inner">
+
+          {/* ── LEFT: avatar card ── */}
+          <aside className="pf-sidebar">
+            <div className="pf-avatar-card">
+              {user.picture ? (
+                <img src={user.picture} alt={user.name} className="pf-avatar-img" />
+              ) : (
+                <div className="pf-avatar-fallback">
+                  {user.name?.charAt(0).toUpperCase()}
+                </div>
+              )}
+              <h2 className="pf-name">{user.name}</h2>
+              <p className="pf-nickname">@{user.nickname}</p>
+
+              {user.email_verified && (
+                <span className="pf-verified-badge">
+                  <FaCheckCircle /> Verified
+                </span>
+              )}
+
+              <div className="pf-avatar-divider" />
+
+              <div className="pf-avatar-meta">
+                <span className="pf-meta-label">Signed in with</span>
+                <span className="pf-meta-value">{providerLabel}</span>
+              </div>
+              {joinDate && (
+                <div className="pf-avatar-meta">
+                  <span className="pf-meta-label">Member since</span>
+                  <span className="pf-meta-value">{joinDate}</span>
+                </div>
+              )}
+
+              <NavLink to="/settings" className="pf-edit-btn">
+                <FaCog /> Account Settings
+              </NavLink>
+            </div>
+          </aside>
+
+          {/* ── RIGHT: details + quick links ── */}
+          <main className="pf-main">
+
+            {/* Info card */}
+            <div className="pf-info-card">
+              <div className="pf-card-header">
+                <FaUser className="pf-card-icon" />
+                <h2>Account Information</h2>
+              </div>
+              <div className="pf-info-rows">
+                {INFO_ROWS.map(row => (
+                  <div className="pf-info-row" key={row.label}>
+                    <div className="pf-info-icon">{row.icon}</div>
+                    <div className="pf-info-content">
+                      <span className="pf-info-label">{row.label}</span>
+                      <span className="pf-info-value">{row.value ?? '—'}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Quick links */}
+            <div className="pf-links-card">
+              <div className="pf-card-header">
+                <FaCar className="pf-card-icon" />
+                <h2>Quick Access</h2>
+              </div>
+              <div className="pf-links-grid">
+                {QUICK_LINKS.map(link => (
+                  <NavLink to={link.to} key={link.to} className="pf-link-item">
+                    <div className="pf-link-icon">{link.icon}</div>
+                    <div className="pf-link-body">
+                      <span className="pf-link-label">{link.label}</span>
+                      <span className="pf-link-desc">{link.desc}</span>
+                    </div>
+                    <HiArrowRight className="pf-link-arrow" />
+                  </NavLink>
+                ))}
+              </div>
+            </div>
+
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Profile;

--- a/frontend/Auto-Sentry/src/pages/Profile/__tests__/Profile.test.jsx
+++ b/frontend/Auto-Sentry/src/pages/Profile/__tests__/Profile.test.jsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import Profile from '../Profile';
+
+vi.mock('@auth0/auth0-react', () => ({
+  useAuth0: () => ({
+    isAuthenticated: true,
+    user: { nickname: 'testuser', name: 'Test User', email: 'test@example.com' },
+    loginWithRedirect: vi.fn(),
+  }),
+}));
+
+describe('Profile page', () => {
+  it('renders the Profile page heading', () => {
+    render(
+      <MemoryRouter initialEntries={['/profile']}>
+        <Routes>
+          <Route path="/profile" element={<Profile />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: /profile/i })).toBeInTheDocument();
+  });
+
+  it('displays the authenticated user name and email', () => {
+    render(
+      <MemoryRouter>
+        <Profile />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Test User/i)).toBeInTheDocument();
+    expect(screen.getByText(/test@example.com/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/Auto-Sentry/src/pages/Settings/Settings.css
+++ b/frontend/Auto-Sentry/src/pages/Settings/Settings.css
@@ -1,0 +1,470 @@
+/* ════════════════════════════════════════
+   SETTINGS PAGE — matches site theme
+════════════════════════════════════════ */
+
+.st-page {
+  min-height: 100vh;
+  background: #f8f9fa;
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+.st-container {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 0 40px;
+}
+
+/* ── HEADER ── */
+.st-header {
+  background: #0a2640;
+  padding: 48px 0 40px;
+  position: relative;
+  overflow: hidden;
+}
+
+.st-header-bg {
+  position: absolute;
+  width: 500px; height: 500px;
+  background: #1c3d5b;
+  border-radius: 50%;
+  top: -280px; right: -120px;
+  pointer-events: none;
+  opacity: 0.7;
+}
+
+.st-header-inner {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.st-eyebrow {
+  display: block;
+  font-size: 11px; font-weight: 700;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: #5de0a5;
+  margin-bottom: 10px;
+}
+
+.st-title {
+  font-size: 40px; font-weight: 900;
+  color: white; letter-spacing: -0.8px;
+  line-height: 1.1; margin: 0 0 8px;
+}
+
+.st-subtitle {
+  font-size: 15px;
+  color: rgba(255,255,255,0.5);
+}
+
+.st-back-btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  color: rgba(255,255,255,0.6);
+  text-decoration: none; font-size: 14px; font-weight: 600;
+  padding: 10px 20px; border-radius: 50px;
+  border: 1px solid rgba(255,255,255,0.15);
+  transition: all 0.2s; white-space: nowrap; flex-shrink: 0;
+}
+.st-back-btn:hover {
+  color: white; border-color: rgba(255,255,255,0.4);
+  background: rgba(255,255,255,0.06);
+}
+
+/* ── BODY ── */
+.st-body { padding: 40px 0 80px; }
+
+.st-body-inner {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 28px;
+  align-items: start;
+}
+
+/* ── SIDE NAV ── */
+.st-sidenav {
+  position: sticky;
+  top: 108px;
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.st-sidenav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 16px;
+  font-size: 13px; font-weight: 600;
+  color: #374151; text-decoration: none;
+  border-bottom: 1px solid #f3f4f6;
+  transition: background 0.15s, color 0.15s;
+}
+
+.st-sidenav-item:last-child { border-bottom: none; }
+.st-sidenav-item:hover { background: #f0fdf4; color: #0a2640; }
+
+.st-sidenav-icon {
+  width: 28px; height: 28px;
+  border-radius: 7px;
+  background: #f3f4f6;
+  color: #6b7280;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 12px; flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
+}
+
+.st-sidenav-item:hover .st-sidenav-icon { background: #5de0a5; color: #0a2640; }
+
+.st-sidenav-arrow {
+  margin-left: auto;
+  font-size: 11px; color: #d1d5db;
+  transition: transform 0.15s;
+}
+
+.st-sidenav-item:hover .st-sidenav-arrow { transform: translateX(2px); color: #0a2640; }
+
+/* ── PANELS ── */
+.st-panels {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* ── CARD ── */
+.st-card {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 20px;
+  overflow: hidden;
+  scroll-margin-top: 108px;
+}
+
+.st-card--danger { border-color: #fecaca; }
+
+.st-card-header {
+  display: flex; align-items: center; gap: 12px;
+  padding: 18px 24px;
+  background: #0a2640;
+}
+
+.st-card-header--danger { background: #dc2626; }
+
+.st-card-header h2 {
+  font-size: 16px; font-weight: 700;
+  color: white; margin: 0;
+}
+
+.st-card-icon { color: #5de0a5; font-size: 15px; }
+.st-card-header--danger .st-card-icon { color: #fecaca; }
+
+.st-card-body {
+  padding: 4px 0 8px;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── TOGGLE ROWS ── */
+.st-toggle-row {
+  display: flex; align-items: center; gap: 14px;
+  padding: 16px 24px;
+  border-bottom: 1px solid #f9fafb;
+  transition: background 0.15s;
+}
+
+.st-toggle-row:last-child { border-bottom: none; }
+.st-toggle-row:hover { background: #fafafa; }
+
+.st-toggle-icon {
+  width: 36px; height: 36px;
+  border-radius: 9px;
+  background: rgba(10,38,64,0.06);
+  color: #0a2640;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 14px; flex-shrink: 0;
+}
+
+.st-toggle-info {
+  flex: 1;
+  display: flex; flex-direction: column; gap: 2px;
+}
+
+.st-toggle-label {
+  font-size: 14px; font-weight: 600; color: #111827;
+}
+
+.st-toggle-desc {
+  font-size: 12px; color: #9ca3af; line-height: 1.4;
+}
+
+.st-toggle-btn {
+  background: none; border: none;
+  font-size: 28px;
+  color: #d1d5db;
+  cursor: pointer;
+  display: flex; align-items: center;
+  padding: 0; flex-shrink: 0;
+  transition: color 0.2s, transform 0.2s;
+}
+
+.st-toggle-btn:hover { transform: scale(1.1); }
+.st-toggle-btn--on { color: #5de0a5; }
+
+/* ── FIELD ROWS ── */
+.st-field-row {
+  display: flex; align-items: center; gap: 16px;
+  padding: 16px 24px;
+  border-bottom: 1px solid #f9fafb;
+  flex-wrap: wrap;
+}
+
+.st-field-row:last-child { border-bottom: none; }
+
+.st-field-info {
+  flex: 1; min-width: 200px;
+  display: flex; flex-direction: column; gap: 2px;
+}
+
+.st-field-label { font-size: 14px; font-weight: 600; color: #111827; }
+.st-field-desc  { font-size: 12px; color: #9ca3af; line-height: 1.4; }
+
+.st-field-control { flex-shrink: 0; }
+
+/* Segment control */
+.st-segment {
+  display: flex;
+  border: 1.5px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.st-segment-btn {
+  padding: 8px 16px;
+  font-size: 13px; font-weight: 600;
+  font-family: 'Inter', sans-serif;
+  background: white; color: #6b7280;
+  border: none; cursor: pointer;
+  border-right: 1px solid #e5e7eb;
+  transition: background 0.15s, color 0.15s;
+}
+
+.st-segment-btn:last-child { border-right: none; }
+.st-segment-btn:hover { background: #f9fafb; color: #111827; }
+
+.st-segment-btn--active {
+  background: #0a2640;
+  color: white;
+}
+
+/* Select */
+.st-select {
+  padding: 9px 12px;
+  border: 1.5px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 13px; font-weight: 600;
+  font-family: 'Inter', sans-serif;
+  color: #111827; background: white;
+  cursor: pointer; outline: none;
+  transition: border-color 0.2s;
+}
+
+.st-select:focus { border-color: #5de0a5; }
+
+/* Colour swatches */
+.st-colour-swatches {
+  display: flex; gap: 8px;
+}
+
+.st-swatch {
+  width: 28px; height: 28px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: transform 0.15s, border-color 0.15s;
+  padding: 0;
+}
+
+.st-swatch:hover { transform: scale(1.15); }
+
+.st-swatch--active {
+  border-color: #111827;
+  box-shadow: 0 0 0 2px white, 0 0 0 4px #111827;
+}
+
+/* ── INFO ROWS (security) ── */
+.st-info-row {
+  display: flex; align-items: center; gap: 14px;
+  padding: 16px 24px;
+  border-bottom: 1px solid #f9fafb;
+  flex-wrap: wrap;
+}
+
+.st-info-row:last-child { border-bottom: none; }
+
+.st-info-icon {
+  width: 36px; height: 36px;
+  border-radius: 9px;
+  background: rgba(10,38,64,0.06);
+  color: #0a2640;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 14px; flex-shrink: 0;
+}
+
+.st-info-icon--red { background: #fff5f5; color: #dc2626; }
+
+.st-info-content {
+  flex: 1; min-width: 180px;
+  display: flex; flex-direction: column; gap: 3px;
+}
+
+.st-info-label { font-size: 13px; font-weight: 700; color: #374151; }
+.st-info-value { font-size: 13px; color: #6b7280; line-height: 1.5; }
+
+/* Badges */
+.st-badge {
+  font-size: 11px; font-weight: 700;
+  padding: 3px 10px; border-radius: 20px;
+  flex-shrink: 0;
+  text-transform: uppercase; letter-spacing: 0.5px;
+}
+
+.st-badge--green { background: #f0fdf4; color: #16a34a; }
+.st-badge--red   { background: #fff5f5; color: #dc2626; }
+
+/* Buttons */
+.st-external-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 13px; font-weight: 600;
+  color: #0a2640; text-decoration: none;
+  padding: 8px 14px; border-radius: 8px;
+  border: 1.5px solid #e5e7eb;
+  transition: all 0.2s; flex-shrink: 0;
+}
+
+.st-external-btn:hover { background: #0a2640; color: white; border-color: #0a2640; }
+
+.st-secondary-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 13px; font-weight: 600;
+  color: #374151; background: #f3f4f6;
+  border: none; padding: 8px 14px;
+  border-radius: 8px; cursor: pointer;
+  font-family: 'Inter', sans-serif;
+  transition: all 0.2s; flex-shrink: 0;
+}
+
+.st-secondary-btn:hover { background: #0a2640; color: white; }
+
+.st-danger-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 13px; font-weight: 700;
+  color: #dc2626; background: #fff5f5;
+  border: 1.5px solid #fecaca;
+  padding: 8px 14px; border-radius: 8px;
+  cursor: pointer; font-family: 'Inter', sans-serif;
+  transition: all 0.2s; flex-shrink: 0;
+}
+
+.st-danger-btn:hover { background: #dc2626; color: white; border-color: #dc2626; }
+
+/* ── SAVE ROW ── */
+.st-save-row {
+  display: flex; justify-content: flex-end;
+  padding-top: 4px;
+}
+
+.st-save-btn {
+  padding: 13px 36px;
+  background: #5de0a5; color: #0a2640;
+  border: none; border-radius: 10px;
+  font-size: 15px; font-weight: 700;
+  font-family: 'Inter', sans-serif;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.15s, box-shadow 0.2s;
+}
+
+.st-save-btn:hover:not(:disabled) {
+  background: #15cdfc;
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(21,205,252,0.35);
+}
+
+.st-save-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+
+/* ── DELETE MODAL ── */
+.st-modal-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.5);
+  backdrop-filter: blur(4px);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 500; padding: 20px;
+}
+
+.st-modal {
+  background: white; border-radius: 20px;
+  padding: 36px 32px; max-width: 420px; width: 100%;
+  box-shadow: 0 24px 64px rgba(0,0,0,0.2);
+  display: flex; flex-direction: column; align-items: center;
+  text-align: center;
+}
+
+.st-modal-icon {
+  width: 56px; height: 56px; border-radius: 50%;
+  background: #fff5f5; color: #dc2626;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 20px; margin-bottom: 16px;
+}
+
+.st-modal h3 {
+  font-size: 20px; font-weight: 800;
+  color: #111827; margin: 0 0 12px;
+}
+
+.st-modal p {
+  font-size: 14px; color: #6b7280;
+  line-height: 1.65; margin-bottom: 28px;
+}
+
+.st-modal-actions { display: flex; gap: 12px; width: 100%; }
+
+.st-modal-btn {
+  flex: 1; padding: 12px; border-radius: 10px;
+  border: none; font-size: 14px; font-weight: 700;
+  font-family: 'Inter', sans-serif; cursor: pointer;
+  transition: background 0.2s;
+}
+
+.st-modal-btn--cancel  { background: #f3f4f6; color: #374151; }
+.st-modal-btn--cancel:hover  { background: #e5e7eb; }
+.st-modal-btn--confirm { background: #dc2626; color: white; }
+.st-modal-btn--confirm:hover { background: #b91c1c; }
+
+/* ════════════════════════════════════════
+   RESPONSIVE
+════════════════════════════════════════ */
+@media (max-width: 768px) {
+  .st-container { padding: 0 20px; }
+  .st-header { padding: 36px 0 28px; }
+  .st-header-inner { flex-direction: column; align-items: flex-start; }
+  .st-title { font-size: 30px; }
+  .st-body { padding: 24px 0 60px; }
+  .st-body-inner { grid-template-columns: 1fr; }
+  .st-sidenav { position: static; flex-direction: row; flex-wrap: wrap; }
+  .st-sidenav-item { flex: 1; min-width: 120px; border-right: 1px solid #f3f4f6; border-bottom: none; }
+  .st-sidenav-arrow { display: none; }
+  .st-field-row { flex-direction: column; align-items: flex-start; }
+}
+
+@media (max-width: 480px) {
+  .st-title { font-size: 26px; }
+  .st-sidenav { flex-direction: column; }
+  .st-sidenav-item { border-right: none; border-bottom: 1px solid #f3f4f6; }
+  .st-modal-actions { flex-direction: column; }
+}

--- a/frontend/Auto-Sentry/src/pages/Settings/Settings.jsx
+++ b/frontend/Auto-Sentry/src/pages/Settings/Settings.jsx
@@ -1,0 +1,351 @@
+import { useState } from 'react';
+import { NavLink } from 'react-router-dom';
+import { useAuth0 } from '@auth0/auth0-react';
+import { toast } from 'react-toastify';
+import './Settings.css';
+import {
+  FaBell, FaCar, FaShieldAlt, FaPalette,
+  FaSignOutAlt, FaTrash, FaToggleOn, FaToggleOff,
+  FaChevronRight, FaCalendarAlt, FaEnvelope,
+} from 'react-icons/fa';
+
+/* ── Default preference state ── */
+const DEFAULT_NOTIFS = {
+  emailReminders:   true,
+  overdueAlerts:    true,
+  weeklyDigest:     false,
+  serviceReminders: true,
+  appUpdates:       false,
+};
+
+const DEFAULT_GARAGE = {
+  defaultMileageUnit: 'km',
+  reminderDaysBefore: '7',
+  autoArchiveDone:    true,
+};
+
+const Settings = () => {
+  const { user, isAuthenticated, logout } = useAuth0();
+
+  const [notifs, setNotifs]         = useState(DEFAULT_NOTIFS);
+  const [garage, setGarage]         = useState(DEFAULT_GARAGE);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [saving, setSaving]         = useState(false);
+
+  if (!isAuthenticated) return null;
+
+  const toggleNotif = (key) =>
+    setNotifs(prev => ({ ...prev, [key]: !prev[key] }));
+
+  const handleSave = () => {
+    setSaving(true);
+    setTimeout(() => {
+      toast.success('Settings saved');
+      setSaving(false);
+    }, 600);
+  };
+
+  /* ── Section data ── */
+  const NOTIF_TOGGLES = [
+    { key: 'emailReminders',   icon: <FaEnvelope />,    label: 'Email Reminders',       desc: 'Receive email reminders for upcoming maintenance tasks' },
+    { key: 'overdueAlerts',    icon: <FaBell />,        label: 'Overdue Alerts',        desc: 'Get notified when a task passes its due date' },
+    { key: 'serviceReminders', icon: <FaCalendarAlt />, label: 'Service Reminders',     desc: 'Reminders before scheduled service appointments' },
+    { key: 'weeklyDigest',     icon: <FaEnvelope />,    label: 'Weekly Digest',         desc: 'A weekly summary of your garage activity' },
+    { key: 'appUpdates',       icon: <FaBell />,        label: 'Product Updates',       desc: 'News about new features and improvements' },
+  ];
+
+  return (
+    <div className="st-page">
+
+      {/* ── HEADER ── */}
+      <div className="st-header">
+        <div className="st-header-bg" aria-hidden="true" />
+        <div className="st-container st-header-inner">
+          <div>
+            <span className="st-eyebrow">Account</span>
+            <h1 className="st-title">Settings</h1>
+            <p className="st-subtitle">Manage your preferences and account options.</p>
+          </div>
+          <NavLink to="/profile" className="st-back-btn">← My Profile</NavLink>
+        </div>
+      </div>
+
+      {/* ── BODY ── */}
+      <div className="st-body">
+        <div className="st-container st-body-inner">
+
+          {/* ── LEFT NAV ── */}
+          <nav className="st-sidenav">
+            {[
+              { href: '#notifications', icon: <FaBell />,      label: 'Notifications'   },
+              { href: '#garage-prefs',  icon: <FaCar />,       label: 'Garage'          },
+              { href: '#appearance',    icon: <FaPalette />,   label: 'Appearance'      },
+              { href: '#security',      icon: <FaShieldAlt />, label: 'Security'        },
+              { href: '#danger-zone',   icon: <FaTrash />,     label: 'Danger Zone'     },
+            ].map(item => (
+              <a key={item.href} href={item.href} className="st-sidenav-item">
+                <span className="st-sidenav-icon">{item.icon}</span>
+                {item.label}
+                <FaChevronRight className="st-sidenav-arrow" />
+              </a>
+            ))}
+          </nav>
+
+          {/* ── MAIN PANELS ── */}
+          <div className="st-panels">
+
+            {/* ── NOTIFICATIONS ── */}
+            <section className="st-card" id="notifications">
+              <div className="st-card-header">
+                <FaBell className="st-card-icon" />
+                <h2>Notifications</h2>
+              </div>
+              <div className="st-card-body">
+                {NOTIF_TOGGLES.map(t => (
+                  <div className="st-toggle-row" key={t.key}>
+                    <div className="st-toggle-icon">{t.icon}</div>
+                    <div className="st-toggle-info">
+                      <span className="st-toggle-label">{t.label}</span>
+                      <span className="st-toggle-desc">{t.desc}</span>
+                    </div>
+                    <button
+                      className={`st-toggle-btn${notifs[t.key] ? ' st-toggle-btn--on' : ''}`}
+                      onClick={() => toggleNotif(t.key)}
+                      aria-label={`Toggle ${t.label}`}
+                      aria-checked={notifs[t.key]}
+                      role="switch"
+                    >
+                      {notifs[t.key] ? <FaToggleOn /> : <FaToggleOff />}
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {/* ── GARAGE PREFERENCES ── */}
+            <section className="st-card" id="garage-prefs">
+              <div className="st-card-header">
+                <FaCar className="st-card-icon" />
+                <h2>Garage Preferences</h2>
+              </div>
+              <div className="st-card-body">
+
+                <div className="st-field-row">
+                  <div className="st-field-info">
+                    <span className="st-field-label">Default Mileage Unit</span>
+                    <span className="st-field-desc">Used across all vehicles and service records</span>
+                  </div>
+                  <div className="st-field-control">
+                    <div className="st-segment">
+                      {['km', 'miles'].map(unit => (
+                        <button
+                          key={unit}
+                          className={`st-segment-btn${garage.defaultMileageUnit === unit ? ' st-segment-btn--active' : ''}`}
+                          onClick={() => setGarage(p => ({ ...p, defaultMileageUnit: unit }))}
+                        >
+                          {unit}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="st-field-row">
+                  <div className="st-field-info">
+                    <span className="st-field-label">Reminder Lead Time</span>
+                    <span className="st-field-desc">Days before due date to send a reminder</span>
+                  </div>
+                  <div className="st-field-control">
+                    <select
+                      className="st-select"
+                      value={garage.reminderDaysBefore}
+                      onChange={e => setGarage(p => ({ ...p, reminderDaysBefore: e.target.value }))}
+                    >
+                      {['1', '3', '5', '7', '14', '30'].map(d => (
+                        <option key={d} value={d}>{d} day{d !== '1' ? 's' : ''} before</option>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+
+                <div className="st-toggle-row">
+                  <div className="st-toggle-icon"><FaCar /></div>
+                  <div className="st-toggle-info">
+                    <span className="st-toggle-label">Auto-archive Completed Tasks</span>
+                    <span className="st-toggle-desc">Automatically move completed tasks out of the active view</span>
+                  </div>
+                  <button
+                    className={`st-toggle-btn${garage.autoArchiveDone ? ' st-toggle-btn--on' : ''}`}
+                    onClick={() => setGarage(p => ({ ...p, autoArchiveDone: !p.autoArchiveDone }))}
+                    role="switch"
+                    aria-checked={garage.autoArchiveDone}
+                  >
+                    {garage.autoArchiveDone ? <FaToggleOn /> : <FaToggleOff />}
+                  </button>
+                </div>
+
+              </div>
+            </section>
+
+            {/* ── APPEARANCE ── */}
+            <section className="st-card" id="appearance">
+              <div className="st-card-header">
+                <FaPalette className="st-card-icon" />
+                <h2>Appearance</h2>
+              </div>
+              <div className="st-card-body">
+                <div className="st-field-row">
+                  <div className="st-field-info">
+                    <span className="st-field-label">Theme</span>
+                    <span className="st-field-desc">Choose your preferred colour scheme</span>
+                  </div>
+                  <div className="st-field-control">
+                    <div className="st-segment">
+                      {['Light', 'Dark', 'System'].map(t => (
+                        <button
+                          key={t}
+                          className={`st-segment-btn${t === 'Light' ? ' st-segment-btn--active' : ''}`}
+                          onClick={() => toast.info('Theme switching coming soon')}
+                        >
+                          {t}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+                <div className="st-field-row">
+                  <div className="st-field-info">
+                    <span className="st-field-label">Accent Colour</span>
+                    <span className="st-field-desc">Primary colour used across buttons and highlights</span>
+                  </div>
+                  <div className="st-field-control st-colour-swatches">
+                    {['#5de0a5', '#15cdfc', '#a78bfa', '#f87171', '#f59e0b'].map(c => (
+                      <button
+                        key={c}
+                        className={`st-swatch${c === '#5de0a5' ? ' st-swatch--active' : ''}`}
+                        style={{ background: c }}
+                        onClick={() => toast.info('Custom themes coming soon')}
+                        aria-label={`Select colour ${c}`}
+                      />
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            {/* ── SECURITY ── */}
+            <section className="st-card" id="security">
+              <div className="st-card-header">
+                <FaShieldAlt className="st-card-icon" />
+                <h2>Security</h2>
+              </div>
+              <div className="st-card-body">
+
+                <div className="st-info-row">
+                  <div className="st-info-icon"><FaShieldAlt /></div>
+                  <div className="st-info-content">
+                    <span className="st-info-label">Authentication Provider</span>
+                    <span className="st-info-value">
+                      Managed by Auth0 — your password and sign-in are handled securely by Auth0.
+                    </span>
+                  </div>
+                  <a
+                    href="https://auth0.com"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="st-external-btn"
+                  >
+                    Auth0 Dashboard <FaChevronRight />
+                  </a>
+                </div>
+
+                <div className="st-info-row">
+                  <div className="st-info-icon"><FaEnvelope /></div>
+                  <div className="st-info-content">
+                    <span className="st-info-label">Email Address</span>
+                    <span className="st-info-value">{user?.email}</span>
+                  </div>
+                  <span className={`st-badge ${user?.email_verified ? 'st-badge--green' : 'st-badge--red'}`}>
+                    {user?.email_verified ? 'Verified' : 'Unverified'}
+                  </span>
+                </div>
+
+                <div className="st-info-row">
+                  <div className="st-info-icon"><FaShieldAlt /></div>
+                  <div className="st-info-content">
+                    <span className="st-info-label">Sign Out Everywhere</span>
+                    <span className="st-info-value">Log out of Auto Sentry on all devices</span>
+                  </div>
+                  <button className="st-secondary-btn" onClick={() => logout()}>
+                    <FaSignOutAlt /> Sign Out
+                  </button>
+                </div>
+
+              </div>
+            </section>
+
+            {/* ── DANGER ZONE ── */}
+            <section className="st-card st-card--danger" id="danger-zone">
+              <div className="st-card-header st-card-header--danger">
+                <FaTrash className="st-card-icon" />
+                <h2>Danger Zone</h2>
+              </div>
+              <div className="st-card-body">
+                <div className="st-info-row">
+                  <div className="st-info-icon st-info-icon--red"><FaTrash /></div>
+                  <div className="st-info-content">
+                    <span className="st-info-label">Delete Account</span>
+                    <span className="st-info-value">
+                      Permanently remove your account and all associated vehicles, tasks, and service history. This cannot be undone.
+                    </span>
+                  </div>
+                  <button
+                    className="st-danger-btn"
+                    onClick={() => setShowDeleteModal(true)}
+                  >
+                    Delete Account
+                  </button>
+                </div>
+              </div>
+            </section>
+
+            {/* Save button */}
+            <div className="st-save-row">
+              <button className="st-save-btn" onClick={handleSave} disabled={saving}>
+                {saving ? 'Saving…' : 'Save Changes'}
+              </button>
+            </div>
+
+          </div>
+        </div>
+      </div>
+
+      {/* ── DELETE CONFIRM MODAL ── */}
+      {showDeleteModal && (
+        <div className="st-modal-overlay" onClick={() => setShowDeleteModal(false)}>
+          <div className="st-modal" onClick={e => e.stopPropagation()}>
+            <div className="st-modal-icon"><FaTrash /></div>
+            <h3>Delete your account?</h3>
+            <p>
+              This will permanently delete your account, all vehicles, maintenance tasks, and service history.
+              This action <strong>cannot be undone</strong>.
+            </p>
+            <div className="st-modal-actions">
+              <button className="st-modal-btn st-modal-btn--cancel" onClick={() => setShowDeleteModal(false)}>
+                Cancel
+              </button>
+              <button
+                className="st-modal-btn st-modal-btn--confirm"
+                onClick={() => { toast.error('Account deletion coming soon'); setShowDeleteModal(false); }}
+              >
+                Yes, Delete Everything
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Settings;

--- a/frontend/Auto-Sentry/src/pages/Settings/__tests__/Settings.test.jsx
+++ b/frontend/Auto-Sentry/src/pages/Settings/__tests__/Settings.test.jsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import Settings from '../Settings';
+
+vi.mock('@auth0/auth0-react', () => ({
+  useAuth0: () => ({
+    isAuthenticated: true,
+    user: { nickname: 'testuser', name: 'Test User', email: 'test@example.com' },
+    loginWithRedirect: vi.fn(),
+  }),
+}));
+
+describe('Settings page', () => {
+  it('renders the Settings page heading', () => {
+    render(
+      <MemoryRouter initialEntries={['/settings']}>
+        <Routes>
+          <Route path="/settings" element={<Settings />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('heading', { name: /settings/i })).toBeInTheDocument();
+  });
+
+  it('renders the settings stub content', () => {
+    render(
+      <MemoryRouter>
+        <Settings />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/settings coming soon/i)).toBeInTheDocument();
+  });
+
+  it('renders a back link to home', () => {
+    render(
+      <MemoryRouter>
+        <Settings />
+      </MemoryRouter>
+    );
+
+    const backLink = screen.getByRole('link');
+    expect(backLink).toHaveAttribute('href', '/');
+  });
+});


### PR DESCRIPTION
Profile page:
- Dark navy header band with eyebrow, title, subtitle
- Two-column layout: sticky avatar sidebar + main content
- Avatar card: Auth0 profile photo (gradient initial fallback), name, username, email-verified badge, sign-in provider, member since, Account Settings link
- Account Information card: icon rows for Name, Email, Username, Sign-in Via, Member Since
- Quick Access card: animated nav links to Garage, Service History, Settings

Settings page:
- Dark navy header band with back-to-profile button
- Sticky left side nav with icon tiles linking to each section
- Notifications section: 5 toggles (email reminders, overdue alerts, service reminders, weekly digest, product updates)
- Garage Preferences: mileage unit segment control, reminder lead time select, auto-archive toggle
- Appearance: theme segment control, accent colour swatches
- Security: Auth0 provider info, email verification badge, sign-out button
- Danger Zone: delete account button with confirm modal
- Save Changes button at bottom